### PR TITLE
fix: resolve v2.1.5 build and deploy regressions

### DIFF
--- a/CHANCHELOG.md
+++ b/CHANCHELOG.md
@@ -2,6 +2,18 @@
 
 Формат журнала основан на принципах Keep a Changelog. Записи сгруппированы по характеру изменения: «Добавлено», «Изменено», «Исправлено», «Удалено» и «Безопасность».
 
+## [Unreleased]
+
+### Исправлено
+
+- Исправлена сборка Rust-сервера на GNU и musl: тип флагов `recvmmsg`/`sendmmsg` выводится из platform-specific libc signature.
+- Scheduler маршрутов сбрасывает stripe при изменении числа активных путей.
+- SSH deploy больше не повреждает `command -v sudo` глобальной подстановкой `sudo -S` (#4).
+- Compose `Flow` страницы настроек создаются через `remember`, поэтому Android lint не сбрасывает collectors при recomposition.
+- Устранены cross-libc false positives Clippy вокруг `cmsghdr` и предупреждения ShellCheck deploy-скрипта.
+- SQLite/WAL/SHM и другие новые server-side secrets создаются с umask `0077`; существующая БД при открытии приводится к `0600`.
+- Версия Rust-клиента синхронизирована с релизом `2.1.5`.
+
 ## [2.1.5] — 2026-08-28
 
 ### Добавлено

--- a/app/src/main/assets/deploy.sh
+++ b/app/src/main/assets/deploy.sh
@@ -100,7 +100,7 @@ run_timed() {
 
 check_root() {
     if [ "$(id -u)" -ne 0 ]; then
-        die "Скрипт должен быть запущен от root. Если sudo отсутствует, зайдите под root и запустите: bash $0 $*"
+        die "Скрипт должен быть запущен от root. Если sudo отсутствует, зайдите под root и запустите: bash $0 install"
     fi
 }
 
@@ -111,6 +111,8 @@ detect_os() {
     if [ ! -f /etc/os-release ]; then
         die "Файл /etc/os-release не найден."
     fi
+    # Runtime distribution metadata exists on every supported server.
+    # shellcheck disable=SC1091
     . /etc/os-release
     OS_ID="${ID:-unknown}"
     case "$OS_ID" in
@@ -340,10 +342,10 @@ fw_add_mss_clamping() {
 }
 
 delete_marked_rules() {
-    local table="$1" chain="$2" marker="$3" i numbers number
+    local table="$1" chain="$2" marker="$3" _ numbers number
     local -a targs=()
     [ "$table" = "filter" ] || targs=(-t "$table")
-    for i in 1 2 3 4 5 6 7 8; do
+    for _ in 1 2 3 4 5 6 7 8; do
         numbers="$(iptables -w "$XT_WAIT" "${targs[@]}" -S "$chain" 2>/dev/null | awk -v chain="$chain" -v marker="$marker" '
 $1 == "-A" && $2 == chain {
     n++
@@ -363,11 +365,11 @@ EOF
 }
 
 ipt_del_repeat() {
-    local table="$1" chain="$2" i
+    local table="$1" chain="$2" _
     shift 2
     local -a targs=()
     [ "$table" = "filter" ] || targs=(-t "$table")
-    for i in 1 2 3 4 5 6 7 8; do
+    for _ in 1 2 3 4 5 6 7 8; do
         iptables -w "$XT_WAIT" "${targs[@]}" -D "$chain" "$@" >/dev/null 2>&1 || break
     done
 }
@@ -405,10 +407,10 @@ cleanup_csqtt_netfilter_rules() {
 }
 
 cleanup_csqtt_proxy_policy() {
-    local i
-    for i in 1 2 3 4; do ip -4 rule del fwmark 0x7531/0x7531 priority 30001 table 30001 >/dev/null 2>&1 || break; done
-    for i in 1 2 3 4; do ip -4 rule del fwmark 0x422 priority 1066 table 1066 >/dev/null 2>&1 || break; done
-    for i in 1 2 3 4; do ip -4 rule del from 10.66.67.0/24 priority 1066 table 1066 >/dev/null 2>&1 || break; done
+    local _
+    for _ in 1 2 3 4; do ip -4 rule del fwmark 0x7531/0x7531 priority 30001 table 30001 >/dev/null 2>&1 || break; done
+    for _ in 1 2 3 4; do ip -4 rule del fwmark 0x422 priority 1066 table 1066 >/dev/null 2>&1 || break; done
+    for _ in 1 2 3 4; do ip -4 rule del from 10.66.67.0/24 priority 1066 table 1066 >/dev/null 2>&1 || break; done
     ip -4 route flush table 30001 >/dev/null 2>&1 || true
     ip -4 route flush table 1066 >/dev/null 2>&1 || true
     ip -4 route flush cache >/dev/null 2>&1 || true
@@ -1221,10 +1223,10 @@ setup_letsencrypt_ip_tls() {
 }
 
 verify_web_panel() {
-    local attempt scheme code
+    local _ scheme code
     local probe_file="/tmp/csqtt-web-probe.$$"
 
-    for attempt in $(seq 1 24); do
+    for _ in $(seq 1 24); do
         for scheme in https http; do
             code="$(curl -k -sS -o "$probe_file" -w "%{http_code}" \
                 --connect-timeout 1 --max-time 2 \

--- a/app/src/main/java/com/csqtt/client/ui/DeployOperations.kt
+++ b/app/src/main/java/com/csqtt/client/ui/DeployOperations.kt
@@ -221,15 +221,11 @@ private class DeploySSHClient(
 
         val result = StringBuilder()
         val progressRegex = Regex("^CSQTT_PROGRESS\\|(\\d+\\.?\\d*)\\|(.+)$")
-        val cmdAdjusted = if (command.contains("sudo") && !command.contains("sudo -S")) {
-            command.replace("sudo ", "sudo -S ")
-        } else command
-
         val sshSession = ssh.startSession()
         return try {
-            val remoteCmd = sshSession.exec(cmdAdjusted)
+            val remoteCmd = sshSession.exec(command)
 
-            if (cmdAdjusted.contains("sudo -S")) {
+            if (command.contains("sudo -S")) {
                 runCatching {
                     remoteCmd.outputStream.write("$sudoPass\n".toByteArray())
                     remoteCmd.outputStream.flush()
@@ -514,10 +510,10 @@ internal fun deployEnvironmentValue(value: String, installInDocker: Boolean): St
 internal fun deployMode(installInDocker: Boolean): String =
     if (installInDocker) "docker" else "systemd"
 
-private fun rootCommand(command: String): String {
+internal fun rootCommand(command: String): String {
     val quoted = shellQuote(command)
     return "if [ \"\$(id -u)\" = \"0\" ]; then bash -c $quoted; " +
-        "elif command -v sudo >/dev/null 2>&1; then sudo bash -c $quoted; " +
+        "elif command -v sudo >/dev/null 2>&1; then sudo -S bash -c $quoted; " +
         "else echo 'error: root privileges required and sudo not found'; exit 1; fi"
 }
 

--- a/app/src/main/java/com/csqtt/client/ui/SettingsTab.kt
+++ b/app/src/main/java/com/csqtt/client/ui/SettingsTab.kt
@@ -94,8 +94,10 @@ internal fun SettingsTabContent(
     validationRequest: Int,
     onVkAuthRequested: () -> Unit,
 ) {
-    val savedWorkersPerHash by settingsStore.workersPerHash
-        .map<Int, Int?> { it }
+    val workersPerHashFlow = remember(settingsStore) {
+        settingsStore.workersPerHash.map<Int, Int?> { it }
+    }
+    val savedWorkersPerHash by workersPerHashFlow
         .collectAsStateWithLifecycle(initialValue = SettingsStore.cachedWorkersPerHash)
 
     val activeProfile = tunnelAuthSettings.profile
@@ -187,8 +189,10 @@ internal fun SettingsTabContent(
     val combinedHashes = remember(vkHash1, vkHash2, vkHash3, vkHash4, vkHash5, vkHash6) {
         allHashes.filter { it.isNotBlank() && it.length >= 16 }.distinct().joinToString(",")
     }
-    val extraWorkersEnabled by settingsStore.extraWorkers
-        .map<Boolean, Boolean?> { it }
+    val extraWorkersFlow = remember(settingsStore) {
+        settingsStore.extraWorkers.map<Boolean, Boolean?> { it }
+    }
+    val extraWorkersEnabled by extraWorkersFlow
         .collectAsStateWithLifecycle(initialValue = SettingsStore.cachedExtraWorkers)
     val effectiveExtraWorkersEnabled = extraWorkersEnabled == true && !accountAutoJsMode
 

--- a/app/src/test/java/com/csqtt/client/ui/DeployResultPolicyTest.kt
+++ b/app/src/test/java/com/csqtt/client/ui/DeployResultPolicyTest.kt
@@ -142,4 +142,14 @@ class DeployResultPolicyTest {
         )
         assertEquals("pa ssword", sanitizeSshPassword("pa\n ss\rword"))
     }
+
+    @Test
+    fun rootCommandAddsSudoStdinFlagOnlyToInvocation() {
+        val command = rootCommand("id")
+
+        assertTrue(command.contains("command -v sudo >/dev/null"))
+        assertTrue(command.contains("sudo -S bash -c"))
+        assertFalse(command.contains("command -v sudo -S"))
+        assertFalse(command.contains("sudo -S not found"))
+    }
 }

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "csqtt-client"
-version = "2.0.5"
+version = "2.1.5"
 edition = "2024"
 rust-version = "1.97.1"
 license = "PolyForm-Noncommercial-1.0.0"

--- a/rust-client/main.rs
+++ b/rust-client/main.rs
@@ -114,6 +114,8 @@ struct Arguments {
     tun_uds: String,
     #[arg(long, default_value_t = false)]
     validate_vk_hashes: bool,
+    #[arg(long, default_value_t = false)]
+    credentials_stdin: bool,
 }
 
 fn main() {
@@ -124,7 +126,13 @@ fn main() {
             let _ = libc::write(libc::STDERR_FILENO, MESSAGE.as_ptr().cast(), MESSAGE.len());
         }
     }));
-    let arguments = Arguments::parse_from(normalized_arguments());
+    let mut arguments = Arguments::parse_from(normalized_arguments());
+    if arguments.credentials_stdin
+        && let Err(error) = read_stdin_credentials(&mut arguments)
+    {
+        eprintln!("[ФАТАЛ] {error:#}");
+        std::process::exit(1);
+    }
     let runtime = match build_runtime(runtime_worker_threads(arguments.workers)) {
         Ok(runtime) => runtime,
         Err(error) => {
@@ -473,6 +481,7 @@ fn normalize_cli_argument(argument: String) -> String {
         "tun-uds",
         "allow-hash-redistribution",
         "validate-vk-hashes",
+        "credentials-stdin",
     ];
     if let Some(value) = argument.strip_prefix('-') {
         let name = value.split('=').next().unwrap_or(value);
@@ -481,6 +490,39 @@ fn normalize_cli_argument(argument: String) -> String {
         }
     }
     argument
+}
+
+#[derive(serde::Deserialize)]
+struct StdinCredentials {
+    password: String,
+    vk: String,
+}
+
+fn apply_stdin_credentials(arguments: &mut Arguments, line: &str) -> Result<()> {
+    const PREFIX: &str = "CSQTT_CREDENTIALS|";
+    if line.len() > 128 * 1024 {
+        bail!("слишком большой пакет credentials stdin");
+    }
+    let payload = line
+        .trim_end_matches(['\r', '\n'])
+        .strip_prefix(PREFIX)
+        .context("неверный префикс credentials stdin")?;
+    let credentials: StdinCredentials =
+        serde_json::from_str(payload).context("неверный JSON credentials stdin")?;
+    if credentials.password.is_empty() || credentials.vk.is_empty() {
+        bail!("credentials stdin не содержит password или vk");
+    }
+    arguments.password = credentials.password;
+    arguments.vk = credentials.vk;
+    Ok(())
+}
+
+fn read_stdin_credentials(arguments: &mut Arguments) -> Result<()> {
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("чтение credentials stdin")?;
+    apply_stdin_credentials(arguments, &line)
 }
 
 async fn read_vk_js_bootstrap() -> Result<vk_js_calls::Bootstrap> {
@@ -795,6 +837,36 @@ mod worker_count_tests {
         .unwrap();
         assert_eq!(arguments.vk, "-Wabc,-Wdef");
         assert!(arguments.allow_hash_redistribution);
+    }
+
+    #[test]
+    fn credentials_stdin_populates_secrets_without_argv() {
+        let mut arguments = Arguments::try_parse_from([
+            "csqtt-client",
+            "--peer",
+            "127.0.0.1:9000",
+            "--credentials-stdin",
+        ])
+        .unwrap();
+        apply_stdin_credentials(
+            &mut arguments,
+            r#"CSQTT_CREDENTIALS|{"password":"secret","vk":"hash-a,hash-b"}"#,
+        )
+        .unwrap();
+        assert_eq!(arguments.password, "secret");
+        assert_eq!(arguments.vk, "hash-a,hash-b");
+    }
+
+    #[test]
+    fn credentials_stdin_rejects_missing_secret() {
+        let mut arguments = Arguments::try_parse_from(["csqtt-client"]).unwrap();
+        assert!(
+            apply_stdin_credentials(
+                &mut arguments,
+                r#"CSQTT_CREDENTIALS|{"password":"","vk":"hash-a"}"#,
+            )
+            .is_err()
+        );
     }
 
     #[tokio::test]

--- a/rust-client/udp_batch.rs
+++ b/rust-client/udp_batch.rs
@@ -291,7 +291,7 @@ mod platform {
                         socket.as_raw_fd(),
                         messages.as_mut_ptr(),
                         packets.len() as libc::c_uint,
-                        libc::MSG_DONTWAIT | libc::MSG_WAITFORONE,
+                        (libc::MSG_DONTWAIT | libc::MSG_WAITFORONE) as _,
                         ptr::null_mut(),
                     )
                 };
@@ -393,7 +393,7 @@ mod platform {
                         socket.as_raw_fd(),
                         messages.as_mut_ptr(),
                         packets.len() as libc::c_uint,
-                        libc::MSG_DONTWAIT | libc::MSG_WAITFORONE,
+                        (libc::MSG_DONTWAIT | libc::MSG_WAITFORONE) as _,
                         ptr::null_mut(),
                     )
                 };
@@ -492,7 +492,7 @@ mod platform {
                         socket.as_raw_fd(),
                         messages.as_mut_ptr(),
                         datagrams.len() as libc::c_uint,
-                        libc::MSG_DONTWAIT,
+                        libc::MSG_DONTWAIT as _,
                     )
                 };
                 if result >= 0 {
@@ -568,7 +568,7 @@ mod platform {
                         socket.as_raw_fd(),
                         messages.as_mut_ptr(),
                         datagrams.len() as libc::c_uint,
-                        libc::MSG_DONTWAIT,
+                        libc::MSG_DONTWAIT as _,
                     )
                 };
                 if result >= 0 {
@@ -654,18 +654,10 @@ mod platform {
     }
 
     fn empty_messages() -> [libc::mmsghdr; MAX_DATAGRAMS] {
-        std::array::from_fn(|_| libc::mmsghdr {
-            msg_hdr: libc::msghdr {
-                msg_name: ptr::null_mut(),
-                msg_namelen: 0,
-                msg_iov: ptr::null_mut(),
-                msg_iovlen: 0,
-                msg_control: ptr::null_mut(),
-                msg_controllen: 0,
-                msg_flags: 0,
-            },
-            msg_len: 0,
-        })
+        // Zero is the documented empty state for every pointer, length and flag
+        // field. Constructing through zeroed also covers libc's private musl
+        // padding fields, which cannot be named in a struct literal.
+        std::array::from_fn(|_| unsafe { std::mem::zeroed() })
     }
 }
 

--- a/rust-server/main.rs
+++ b/rust-server/main.rs
@@ -1821,6 +1821,12 @@ fn print_cli_help() {
 }
 
 fn main() -> Result<()> {
+    #[cfg(unix)]
+    unsafe {
+        // The server creates credentials, SQLite/WAL files and TLS keys.
+        // Restrict every new file before any worker thread can create one.
+        libc::umask(0o077);
+    }
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .max_blocking_threads(1)

--- a/rust-server/model.rs
+++ b/rust-server/model.rs
@@ -591,6 +591,20 @@ const LEGACY_DATABASE_FILE: &str = "passwords.json";
 const LEGACY_DATABASE_IMPORTED_FILE: &str = "passwords.json.imported";
 const LEGACY_DATABASE_FILES: [&str; 2] = [LEGACY_DATABASE_FILE, LEGACY_DATABASE_IMPORTED_FILE];
 
+#[cfg(unix)]
+fn secure_database_file_permissions(config_dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    for name in [DATABASE_FILE, "csqtt.db-wal", "csqtt.db-shm"] {
+        let path = config_dir.join(name);
+        if path.exists() {
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("secure {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
 const DATABASE_SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
@@ -649,6 +663,8 @@ fn open_database_connection(config_dir: &Path) -> Result<Connection> {
         fs::set_permissions(config_dir, fs::Permissions::from_mode(0o700))?;
     }
     let path = config_dir.join(DATABASE_FILE);
+    #[cfg(unix)]
+    secure_database_file_permissions(config_dir)?;
     let connection = Connection::open(&path).with_context(|| format!("open {}", path.display()))?;
     connection
         .pragma_update(None, "journal_mode", "WAL")
@@ -659,6 +675,8 @@ fn open_database_connection(config_dir: &Path) -> Result<Connection> {
     connection
         .execute_batch(DATABASE_SCHEMA)
         .with_context(|| format!("schema {}", path.display()))?;
+    #[cfg(unix)]
+    secure_database_file_permissions(config_dir)?;
     Ok(connection)
 }
 
@@ -1327,6 +1345,28 @@ mod tests {
         ClientDevice, Database, DatabasePersistence, PasswordEntry, PersistenceQueue,
         PersistenceUpdate, TrafficCounters, TrafficSnapshot, load_database, save_database,
     };
+
+    #[cfg(unix)]
+    #[test]
+    fn database_files_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!("csqtt-db-mode-test-{unique}"));
+
+        save_database(&directory, &Database::default()).expect("save database");
+        let mode = std::fs::metadata(directory.join(super::DATABASE_FILE))
+            .expect("database metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(mode, 0o600);
+        let _ = std::fs::remove_dir_all(directory);
+    }
 
     #[test]
     fn dns_survives_database_restart() {

--- a/rust-server/protocol.rs
+++ b/rust-server/protocol.rs
@@ -5168,9 +5168,9 @@ mod tests {
         let alive = round.alive_payload(30_100).unwrap();
         assert!(alive.starts_with(STREAM_ALIVE_PREFIX));
         assert_ne!(repair, alive);
-        assert!(round.alive_payload(5_500).is_none());
-        assert!(round.alive_payload(10_100).is_some());
-        assert!(round.alive_payload(15_100).is_none());
+        assert!(round.alive_payload(35_500).is_none());
+        assert!(round.alive_payload(40_100).is_some());
+        assert!(round.alive_payload(45_100).is_none());
     }
 
     #[test]

--- a/rust-server/tokio_io.rs
+++ b/rust-server/tokio_io.rs
@@ -489,7 +489,7 @@ impl TokioIo {
                         udp_fd,
                         self.rx_msgs.as_mut_ptr(),
                         receive_limit as libc::c_uint,
-                        (libc::MSG_DONTWAIT | libc::MSG_WAITFORONE) as libc::c_uint,
+                        (libc::MSG_DONTWAIT | libc::MSG_WAITFORONE) as _,
                         std::ptr::null_mut(),
                     )
                 };
@@ -544,6 +544,7 @@ impl TokioIo {
             else {
                 continue;
             };
+            #[allow(clippy::unnecessary_cast)] // cmsghdr field differs across libc targets.
             let control_len =
                 (msg.msg_hdr.msg_controllen as usize).min(self.rx_controls[index].len());
             let local_ip = parse_ipv4_pktinfo_destination(unsafe {
@@ -743,7 +744,7 @@ impl TokioIo {
                             udp_fd,
                             self.tx_msgs.as_mut_ptr(),
                             batch_len as libc::c_uint,
-                            libc::MSG_DONTWAIT as libc::c_uint,
+                            libc::MSG_DONTWAIT as _,
                         )
                     };
                     if result < 0 {
@@ -1037,6 +1038,7 @@ fn cmsg_align(length: usize) -> usize {
 fn parse_ipv4_pktinfo_destination(mut control: &[u8]) -> Option<Ipv4Addr> {
     while control.len() >= std::mem::size_of::<libc::cmsghdr>() {
         let header = unsafe { &*(control.as_ptr().cast::<libc::cmsghdr>()) };
+        #[allow(clippy::unnecessary_cast)] // cmsghdr field differs across libc targets.
         let length = header.cmsg_len as usize;
         if length < std::mem::size_of::<libc::cmsghdr>() || length > control.len() {
             break;

--- a/rust-server/tproxy.rs
+++ b/rust-server/tproxy.rs
@@ -1474,6 +1474,7 @@ mod linux {
     pub(super) fn parse_orig_dst(mut control: &[u8]) -> Option<SocketAddrV4> {
         while control.len() >= mem::size_of::<libc::cmsghdr>() {
             let header: &libc::cmsghdr = unsafe { &*(control.as_ptr() as *const libc::cmsghdr) };
+            #[allow(clippy::unnecessary_cast)] // cmsghdr field differs across libc targets.
             let length = header.cmsg_len as usize;
             if length < mem::size_of::<libc::cmsghdr>() || length > control.len() {
                 break;

--- a/rust-server/tun_device.rs
+++ b/rust-server/tun_device.rs
@@ -43,6 +43,7 @@ impl RouteSelection {
 struct LocalStripeCursor {
     next: usize,
     remaining: usize,
+    path_count: usize,
 }
 
 #[derive(Default)]
@@ -63,7 +64,8 @@ impl LocalStripedScheduler {
             PacketClass::Priority => (&mut self.priority, PRIORITY_STRIPE_PACKET_CHUNK),
             PacketClass::Bulk => (&mut self.bulk, BULK_STRIPE_PACKET_CHUNK),
         };
-        if cursor.next >= count {
+        if cursor.path_count != count {
+            cursor.path_count = count;
             cursor.next = 0;
             cursor.remaining = 0;
         }


### PR DESCRIPTION
## Что исправлено

- устранена несовместимость `recvmmsg`/`sendmmsg` flags и `msghdr` между GNU и musl;
- добавлен opt-in `--credentials-stdin`: desktop wrappers могут передавать пароль и VK links через stdin, не раскрывая их в process argv;
- scheduler маршрутов сбрасывает stripe при изменении числа активных путей;
- исправлены временные отметки теста повторной отправки `STREAM_ALIVE`;
- устранена глобальная подстановка `sudo -> sudo -S`, повреждавшая `command -v sudo` под `zsh`/строгими shell;
- Compose `Flow` на странице настроек создаются через `remember`, поэтому collectors не пересоздаются при recomposition и Android lint проходит;
- server process устанавливает umask `0077`, а существующие SQLite/WAL/SHM при открытии приводятся к `0600`;
- версия `rust-client` синхронизирована с `v2.1.5`.

Fixes #4.

## Проверки

- `cargo +1.97.1 test --locked` (`rust-client`): 247 passed, 4 ignored;
- `cargo +1.97.1 zigbuild --release --locked --target x86_64-unknown-linux-musl`: passed;
- `cargo +1.97.1 test --offline --target x86_64-unknown-linux-gnu` (`rust-server`): 102 passed;
- `./gradlew testDebugUnitTest lintDebug --no-daemon`: BUILD SUCCESSFUL;
- `cargo fmt --all -- --check`: passed для обоих Rust crates;
- `cargo clippy --all-targets -- -D warnings`: passed;
- `shellcheck app/src/main/assets/deploy.sh`: passed;
- `git diff --check`: passed.

Fork-specific URLs, ports и version bump намеренно не включены.
